### PR TITLE
Url fix

### DIFF
--- a/app/assets/javascripts/concerto_weather/weather.js
+++ b/app/assets/javascripts/concerto_weather/weather.js
@@ -65,7 +65,7 @@ function buildResultsTable(data) {
 
 function searchForCityInfo() {
   var info_el = $(".city-info");
-  var cityQuery = $("input#weather_config_city_query").val();
+  var cityQuery = encodeURIComponent($("input#weather_config_city_query").val());
 
   if (info_el.length != 0 && cityQuery.length > 0) {
     // clear out any prior selected city

--- a/app/assets/javascripts/concerto_weather/weather.js
+++ b/app/assets/javascripts/concerto_weather/weather.js
@@ -65,7 +65,7 @@ function buildResultsTable(data) {
 
 function searchForCityInfo() {
   var info_el = $(".city-info");
-  var cityQuery = encodeURIComponent($("input#weather_config_city_query").val());
+  var cityQuery = $("input#weather_config_city_query").val();
 
   if (info_el.length != 0 && cityQuery.length > 0) {
     // clear out any prior selected city

--- a/app/controllers/concerto_weather/search_controller.rb
+++ b/app/controllers/concerto_weather/search_controller.rb
@@ -14,9 +14,9 @@ module ConcertoWeather
         require 'json'
         require 'erb'
 
-        query_url=ERB::Util.url_encode(query)
+        query_escaped=ERB::Util.url_encode(query)
         appid = ConcertoConfig["open_weather_map_api_key"]
-        url = "http://api.openweathermap.org/data/2.5/find?q=#{query_url}&type=like&mode=json&appid=#{appid}"
+        url = "http://api.openweathermap.org/data/2.5/find?q=#{query_escaped}&type=like&mode=json&appid=#{appid}"
         return Net::HTTP.get(URI(url))
       end
   end

--- a/app/controllers/concerto_weather/search_controller.rb
+++ b/app/controllers/concerto_weather/search_controller.rb
@@ -12,9 +12,11 @@ module ConcertoWeather
       def getOpenWeatherCities(query)
         require 'net/http'
         require 'json'
+        require 'erb'
 
+        query_url=ERB::Util.url_encode(query)
         appid = ConcertoConfig["open_weather_map_api_key"]
-        url = "http://api.openweathermap.org/data/2.5/find?q=#{query}&type=like&mode=json&appid=#{appid}"
+        url = "http://api.openweathermap.org/data/2.5/find?q=#{query_url}&type=like&mode=json&appid=#{appid}"
         return Net::HTTP.get(URI(url))
       end
   end


### PR DESCRIPTION
Currently, searching for cities with spaces in their names (Like "Buenos Aires" or "Los Angeles") would fail since the value was passed  "as is" to the search component. Implemented a URL-endoding on the query parameter on the server side. 