### PR TITLE
fix emptyhtml variable name

### DIFF
--- a/app/models/weather.rb
+++ b/app/models/weather.rb
@@ -118,7 +118,7 @@ class Weather < DynamicContent
     format_string = self.config['format_string']
 
     if format_string.blank? 
-       rawhtml = empty_html
+       rawhtml = emptyhtml
     else 
        rawhtml = eval("\"" + format_string + "\"")
     end


### PR DESCRIPTION
Resolve a bug (500 error) when creating a weather forecast content with an empty "format string". The emptyhtml variable was wrongly named.