### PR TITLE
update open street map to https url

### DIFF
--- a/app/assets/javascripts/concerto_weather/weather.js
+++ b/app/assets/javascripts/concerto_weather/weather.js
@@ -24,7 +24,7 @@ function reverseGeocode(place) {
   };
 
   $.ajax({
-    url: "//nominatim.openstreetmap.org/reverse",
+    url: "https://nominatim.openstreetmap.org/reverse",
     data: params,
     dataType: "json",
     success: function(data) {


### PR DESCRIPTION
Open Street map starting returning 301 errors on the non-https url. Forcing the url to https so that we can properly retrieve the reverse search results regardless of whether concerto is hosted in http or https.